### PR TITLE
Fix subgroup move ordering and cycle guards

### DIFF
--- a/models/group/group.go
+++ b/models/group/group.go
@@ -480,6 +480,25 @@ func UpdateGroup(ctx context.Context, group *Group) error {
 
 func MoveGroup(ctx context.Context, group *Group, newParent int64, newSortOrder int) error {
 	sess := db.GetEngine(ctx)
+	if newParent == group.ID {
+		return util.NewInvalidArgumentErrorf("cannot move group %d under itself", group.ID)
+	}
+
+	parentGroupChain, err := GetParentGroupChain(ctx, newParent)
+	if err != nil {
+		return err
+	}
+	for _, parent := range parentGroupChain {
+		if parent.ID == group.ID {
+			return util.NewInvalidArgumentErrorf("cannot move group %d under one of its descendants", group.ID)
+		}
+	}
+	if len(parentGroupChain) >= 20 {
+		return ErrGroupTooDeep{
+			ID: group.ID,
+		}
+	}
+
 	ng, err := GetGroupByID(ctx, newParent)
 	if err != nil && !IsErrGroupNotExist(err) {
 		return err
@@ -504,17 +523,14 @@ func MoveGroup(ctx context.Context, group *Group, newParent int64, newSortOrder 
 			return err
 		}
 	}
-	siblings = util.SliceInsert(util.SliceRemove(tmpSiblings, group.SortOrder), group, newSortOrder)
 
-	parentGroupChain, err := GetParentGroupChain(ctx, newParent)
-	if err != nil {
-		return err
-	}
-	if len(parentGroupChain) >= 20 {
-		return ErrGroupTooDeep{
-			ID: group.ID,
+	for _, sibling := range tmpSiblings {
+		if sibling.ID != group.ID {
+			siblings = append(siblings, sibling)
 		}
 	}
+	siblings = util.SliceInsert(siblings, group, newSortOrder)
+
 	err = group.LoadOwner(ctx)
 	if err != nil {
 		return err
@@ -536,8 +552,8 @@ func MoveGroup(ctx context.Context, group *Group, newParent int64, newSortOrder 
 		}
 	}
 
-	if group.ParentGroup != nil && newParent != 0 {
-		group.ParentGroup = nil
+	group.ParentGroup = nil
+	if newParent != 0 {
 		if err = group.LoadParentGroup(ctx); err != nil {
 			return err
 		}

--- a/models/group/group_test.go
+++ b/models/group/group_test.go
@@ -45,6 +45,7 @@ func assertGroupOrder(t *testing.T, pgid int64, expectedIDs []int64) {
 	err := e.Where(builder.Eq{"parent_group_id": pgid}).Asc("sort_order").Find(&groups)
 	mappedIDs := util.SliceMap(groups, getID)
 	assert.NoError(t, err)
+	assert.Len(t, groups, len(expectedIDs))
 	for i, group := range mappedIDs {
 		assert.Equal(t, expectedIDs[i], group)
 		assert.Equal(t, i, groups[i].SortOrder)
@@ -102,5 +103,45 @@ func TestMoveGroup(t *testing.T) {
 		end := util.SliceMap(groups[4:], getID)
 		onlyItem := []int64{groups[3].ID}
 		assertGroupOrder(t, parentGroup.ID, combineSlices(first, end, onlyItem))
+	})
+	t.Run("ToEmptyParent", func(t *testing.T) {
+		oldParent, groups := createParentGroup(t)
+		newParent := createTestGroup(t, "empty parent", 0)
+		err := group_model.MoveGroup(t.Context(), groups[3], newParent.ID, 0)
+		assert.NoError(t, err)
+		first := util.SliceMap(groups[0:3], getID)
+		end := util.SliceMap(groups[4:], getID)
+		assertGroupOrder(t, oldParent.ID, combineSlices(first, end))
+		assertGroupOrder(t, newParent.ID, []int64{groups[3].ID})
+	})
+	t.Run("ToDifferentParentWithSiblings", func(t *testing.T) {
+		oldParent, groups := createParentGroup(t)
+		newParent, newSiblings := createParentGroup(t)
+		err := group_model.MoveGroup(t.Context(), groups[3], newParent.ID, 1)
+		assert.NoError(t, err)
+		first := util.SliceMap(groups[0:3], getID)
+		end := util.SliceMap(groups[4:], getID)
+		assertGroupOrder(t, oldParent.ID, combineSlices(first, end))
+		assertGroupOrder(t, newParent.ID, combineSlices(
+			util.SliceMap(newSiblings[0:1], getID),
+			[]int64{groups[3].ID},
+			util.SliceMap(newSiblings[1:], getID),
+		))
+	})
+	t.Run("RejectsMovingUnderSelf", func(t *testing.T) {
+		parentGroup, _ := createParentGroup(t)
+		err := group_model.MoveGroup(t.Context(), parentGroup, parentGroup.ID, 0)
+		assert.ErrorIs(t, err, util.ErrInvalidArgument)
+		reloaded, err := group_model.GetGroupByID(t.Context(), parentGroup.ID)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 0, reloaded.ParentGroupID)
+	})
+	t.Run("RejectsMovingUnderDescendant", func(t *testing.T) {
+		parentGroup, groups := createParentGroup(t)
+		child := createTestGroup(t, "child group", groups[3].ID)
+		err := group_model.MoveGroup(t.Context(), groups[3], child.ID, 0)
+		assert.ErrorIs(t, err, util.ErrInvalidArgument)
+		assertGroupOrder(t, parentGroup.ID, util.SliceMap(groups, getID))
+		assertGroupOrder(t, groups[3].ID, []int64{child.ID})
 	})
 }

--- a/modules/util/slice.go
+++ b/modules/util/slice.go
@@ -92,15 +92,12 @@ func SliceRemove[T any](slice []T, oldIndex int) []T {
 	}
 	oldIndex = max(0, min(oldIndex, len(slice)-1))
 	withoutCurrent := slice[0:oldIndex]
-	itemsUpper := slice[min(oldIndex+1, len(slice)-1):]
+	itemsUpper := slice[oldIndex+1:]
 	withoutCurrent = append(withoutCurrent, itemsUpper...)
 	return withoutCurrent
 }
 
 func SliceInsert[T any](slice []T, item T, newIndex int) []T {
-	if len(slice) == 0 {
-		return slice
-	}
 	oldLen := len(slice)
 	newIndex = min(newIndex, len(slice))
 	if newIndex < 0 {

--- a/modules/util/slice_test.go
+++ b/modules/util/slice_test.go
@@ -53,3 +53,20 @@ func TestSliceRemoveAll(t *testing.T) {
 	assert.ElementsMatch(t, []float64{2, 2, 3}, SliceRemoveAll([]float64{2, 0, 2, 3}, 0))
 	assert.ElementsMatch(t, []bool{false, false}, SliceRemoveAll([]bool{false, true, false}, true))
 }
+
+func TestSliceRemove(t *testing.T) {
+	assert.Equal(t, []int{2, 3}, SliceRemove([]int{1, 2, 3}, 0))
+	assert.Equal(t, []int{1, 3}, SliceRemove([]int{1, 2, 3}, 1))
+	assert.Equal(t, []int{1, 2}, SliceRemove([]int{1, 2, 3}, 2))
+	assert.Equal(t, []int{1, 2}, SliceRemove([]int{1, 2, 3}, 10))
+	assert.Equal(t, []int{2, 3}, SliceRemove([]int{1, 2, 3}, -10))
+	assert.Empty(t, SliceRemove([]int{}, 0))
+}
+
+func TestSliceInsert(t *testing.T) {
+	assert.Equal(t, []int{1}, SliceInsert([]int{}, 1, 0))
+	assert.Equal(t, []int{1, 2, 3}, SliceInsert([]int{2, 3}, 1, 0))
+	assert.Equal(t, []int{1, 2, 3}, SliceInsert([]int{1, 3}, 2, 1))
+	assert.Equal(t, []int{1, 2, 3}, SliceInsert([]int{1, 2}, 3, 10))
+	assert.Equal(t, []int{1, 2, 3}, SliceInsert([]int{1, 2}, 3, -10))
+}


### PR DESCRIPTION
## Summary

This tightens the subgroup move path in the active #1872 implementation:

- avoids dropping an unrelated sibling when moving a group into a different parent
- persists moves into an empty parent by fixing `SliceInsert` for empty slices
- fixes `SliceRemove` when removing the last element
- rejects moving a group under itself or one of its descendants to avoid cycles in the subgroup tree

## Why

`MoveGroup` was removing from the target parent's sibling slice using the moving group's old sort index. That works only when the source and target parent are the same. When the parent changes, it can remove the wrong target sibling before inserting the moved group. Empty targets also had no persisted update because the insert helper returned the original empty slice.

## Tests

- `go test ./modules/util ./models/group`
- `go test ./services/group`
- `TAGS='bindata gogit' make generate-go`
- `GITEA_TEST_DATABASE=sqlite go test -tags 'bindata gogit' ./tests/integration -run TestAPIGroup`
